### PR TITLE
Log improvements for timing information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
+    "codetiming",
     "typer >= 0.4.0",
     "rich >=10.12.0",
 ]

--- a/src/xrdsum/backends/_hdfs.py
+++ b/src/xrdsum/backends/_hdfs.py
@@ -9,6 +9,8 @@ from contextlib import closing
 from dataclasses import dataclass
 from typing import IO, Any, Generator
 
+from codetiming import Timer
+
 from ..checksums import Checksum
 from ..logger import APP_LOGGER_NAME
 from ._base import XrdsumBackend
@@ -130,7 +132,10 @@ class HDFSBackend(XrdsumBackend):
             return checksum
         # try to get from metadata
         xattr_name = XATTR_TEMPLATE.format(checksum.name)
-        xattr_value = self._get_xattr(xattr_name)
+        with Timer(
+            text=f"HDFS get_xattr took {{:.3f}}s for {self.file_path}", logger=log.debug
+        ):
+            xattr_value = self._get_xattr(xattr_name)
         if xattr_value:
             log.debug(
                 "Found checksum %s in metadata (%s=%s) for file %s",

--- a/src/xrdsum/backends/_hdfs.py
+++ b/src/xrdsum/backends/_hdfs.py
@@ -133,7 +133,8 @@ class HDFSBackend(XrdsumBackend):
         # try to get from metadata
         xattr_name = XATTR_TEMPLATE.format(checksum.name)
         with Timer(
-            text=f"HDFS get_xattr took {{:.3f}}s for {self.file_path}", logger=log.debug
+            text=f"HDFS get_xattr took {{:.3f}}s for {self.file_path}",
+            logger=log.timing,  # type: ignore[attr-defined]
         ):
             xattr_value = self._get_xattr(xattr_name)
         if xattr_value:
@@ -147,9 +148,13 @@ class HDFSBackend(XrdsumBackend):
             checksum.value = xattr_value
             return checksum
         # did not find it in metadata, try calculating it
-        checksum.value = checksum.calculate(
-            read_file_in_chunks(self.file_path, self.settings.read_size)
-        )
+        with Timer(
+            text=f"HDFS checksum calculation took {{:.3f}}s for {self.file_path}",
+            logger=log.timing,  # type: ignore[attr-defined]
+        ):
+            checksum.value = checksum.calculate(
+                read_file_in_chunks(self.file_path, self.settings.read_size)
+            )
 
         return checksum
 

--- a/src/xrdsum/cli.py
+++ b/src/xrdsum/cli.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 import typer
+from codetiming import Timer
 
 from .backends import FILE_SYSTEMS
 from .checksums import AVAILABLE_CHECKSUM_TYPES, Checksum
@@ -74,9 +75,13 @@ Smaller values will use less memory, larger sizes may have benefits in IO perfor
     except KeyError as exception:
         log.error("Unknown checksum type %s", checksum_type)
         raise typer.Exit(code=1) from exception
-    checksum = hdfs.get_checksum(checksum)
+    with Timer(text=f"HDFS checksum took {{:.3f}}s for {file_path}", logger=log.debug):
+        checksum = hdfs.get_checksum(checksum)
     if store_result:
-        hdfs.store_checksum(checksum)
+        with Timer(
+            text=f"Storing checksum took {{:.3f}}s for {file_path}", logger=log.debug
+        ):
+            hdfs.store_checksum(checksum)
     typer.echo(checksum.value)
 
 

--- a/src/xrdsum/cli.py
+++ b/src/xrdsum/cli.py
@@ -66,7 +66,7 @@ Smaller values will use less memory, larger sizes may have benefits in IO perfor
     read_size *= 1024 * 1024
     file_path = resolve_file_path(file_path, storage_catalog=storage_catalog)
     try:
-        fs = FILE_SYSTEMS[file_system](file_path, read_size)
+        fs_handle = FILE_SYSTEMS[file_system](file_path, read_size)
     except KeyError as exception:
         log.error("Unknown file system %s", file_system)
         raise typer.Exit(code=1) from exception
@@ -79,13 +79,13 @@ Smaller values will use less memory, larger sizes may have benefits in IO perfor
         text=f"HDFS checksum took {{:.3f}}s for {file_path}",
         logger=log.timing,  # type: ignore[attr-defined]
     ):
-        checksum = fs.get_checksum(checksum)
+        checksum = fs_handle.get_checksum(checksum)
     if store_result:
         with Timer(
             text=f"Storing checksum took {{:.3f}}s for {file_path}",
             logger=log.timing,  # type: ignore[attr-defined]
         ):
-            fs.store_checksum(checksum)
+            fs_handle.store_checksum(checksum)
     typer.echo(checksum.value)
 
 

--- a/src/xrdsum/cli.py
+++ b/src/xrdsum/cli.py
@@ -75,11 +75,15 @@ Smaller values will use less memory, larger sizes may have benefits in IO perfor
     except KeyError as exception:
         log.error("Unknown checksum type %s", checksum_type)
         raise typer.Exit(code=1) from exception
-    with Timer(text=f"HDFS checksum took {{:.3f}}s for {file_path}", logger=log.debug):
+    with Timer(
+        text=f"HDFS checksum took {{:.3f}}s for {file_path}",
+        logger=log.timing,  # type: ignore[attr-defined]
+    ):
         checksum = fs.get_checksum(checksum)
     if store_result:
         with Timer(
-            text=f"Storing checksum took {{:.3f}}s for {file_path}", logger=log.debug
+            text=f"Storing checksum took {{:.3f}}s for {file_path}",
+            logger=log.timing,  # type: ignore[attr-defined]
         ):
             fs.store_checksum(checksum)
     typer.echo(checksum.value)

--- a/src/xrdsum/cli.py
+++ b/src/xrdsum/cli.py
@@ -66,7 +66,7 @@ Smaller values will use less memory, larger sizes may have benefits in IO perfor
     read_size *= 1024 * 1024
     file_path = resolve_file_path(file_path, storage_catalog=storage_catalog)
     try:
-        hdfs = FILE_SYSTEMS[file_system](file_path, read_size)
+        fs = FILE_SYSTEMS[file_system](file_path, read_size)
     except KeyError as exception:
         log.error("Unknown file system %s", file_system)
         raise typer.Exit(code=1) from exception
@@ -76,12 +76,12 @@ Smaller values will use less memory, larger sizes may have benefits in IO perfor
         log.error("Unknown checksum type %s", checksum_type)
         raise typer.Exit(code=1) from exception
     with Timer(text=f"HDFS checksum took {{:.3f}}s for {file_path}", logger=log.debug):
-        checksum = hdfs.get_checksum(checksum)
+        checksum = fs.get_checksum(checksum)
     if store_result:
         with Timer(
             text=f"Storing checksum took {{:.3f}}s for {file_path}", logger=log.debug
         ):
-            hdfs.store_checksum(checksum)
+            fs.store_checksum(checksum)
     typer.echo(checksum.value)
 
 


### PR DESCRIPTION
## Changes
- adds `codetiming` dependency
- added time (in seconds) needed to
  - retrieve checksum from `xattr`
  - calculate checksum
  - store checksum in `xattr`
- total (in seconds) time for `get_checksum`
- added new `TIMING` log level for easier search in logs